### PR TITLE
Add above site facility dashboard link override

### DIFF
--- a/configuration/frontend_configuration/configs/kenyaemr.config.json
+++ b/configuration/frontend_configuration/configs/kenyaemr.config.json
@@ -344,5 +344,8 @@
   },
   "@kenyaemr/esm-version-app": {
     "extensionSlots": {}
+  },
+  "@kenyaemr/esm-facility-dashboard-app": {
+    "facilityDashboardAboveSiteUrl": "http://34.35.62.41:8080"
   }
 }

--- a/configuration/frontend_configuration/configs/kenyaemr.config.json
+++ b/configuration/frontend_configuration/configs/kenyaemr.config.json
@@ -346,6 +346,10 @@
     "extensionSlots": {}
   },
   "@kenyaemr/esm-facility-dashboard-app": {
-    "facilityDashboardAboveSiteUrl": "http://34.35.62.41:8080"
+    "showAirAndReportLinks": true,
+    "facilityDashboardAboveSiteUrl": "http://34.35.62.41:8080/dashboard/1"
+  },
+  "@kenyaemr/esm-patient-flags-app": {
+    "instanceName": ""
   }
 }


### PR DESCRIPTION
<img width="1440" height="900" alt="Screenshot 2025-08-12 at 22 09 53" src="https://github.com/user-attachments/assets/7849587c-1eaa-45f9-baac-48688860faa5" />


https://github.com/user-attachments/assets/6e958d24-ef34-439f-9ce6-7c6a87d86177

Though the dashboard link aint complete cause @vicwere shared `http://34.35.62.41:8080/login/` and wee need full dashboard url and should end with `/dashboard/<dashboard-id>`, but i have followed up, tommorow hell probably send it